### PR TITLE
Remove RT_GROUP_SCHED from default selection

### DIFF
--- a/drivers/misc/mediatek/Kconfig.default
+++ b/drivers/misc/mediatek/Kconfig.default
@@ -157,7 +157,6 @@ config ANDROID_DEFAULT_SETTING
 	select PROC_FS
 	select PROFILING
 	select RTC_CLASS
-	select RT_GROUP_SCHED
 	select SECCOMP
 	select SECCOMP_FILTER
 	select SECURITY

--- a/kernel/sched/rt.c
+++ b/kernel/sched/rt.c
@@ -2079,7 +2079,9 @@ static int push_rt_task(struct rq *rq)
 	struct task_struct *next_task;
 	struct rq *lowest_rq;
 	int ret = 0;
+#ifdef CONFIG_RT_GROUP_SCHED
 	struct rt_rq *rt_rq;
+#endif
 
 	if (!rq->rt.overloaded)
 		return 0;
@@ -2103,11 +2105,15 @@ retry:
 	 * just reschedule current.
 	 */
 	if (unlikely(next_task->prio < rq->curr->prio)) {
+#ifdef CONFIG_RT_GROUP_SCHED
 		/* We only reschedule when next_task not throttle */
 		if (!rt_rq_throttled(rt_rq)) {
+#endif
 			resched_curr(rq);
 			return 0;
+#ifdef CONFIG_RT_GROUP_SCHED
 		}
+#endif
 	}
 
 	/* We might release rq lock */

--- a/kernel/sched/rt.c
+++ b/kernel/sched/rt.c
@@ -2089,7 +2089,9 @@ static int push_rt_task(struct rq *rq)
 		return 0;
 
 retry:
+#ifdef CONFIG_RT_GROUP_SCHED
 	rt_rq = next_task->rt.rt_rq;
+#endif
 	if (unlikely(next_task == rq->curr)) {
 		WARN_ON(1);
 		return 0;


### PR DESCRIPTION
This PR removes CONFIG_RT_GROUP_SCHED from the default Kconfig selection and fixes building the kernel when it's actually turned off.

This allows rtkit to set the right real-time scheduler priority successfully.

Fixes: https://github.com/HelloVolla/ubuntu-touch-beta-tests/issues/33