### PR TITLE
power: mediatek: cw2015_fuel_gauge: Stop reporting sysfs properties

### DIFF
--- a/drivers/power/mediatek/battery/cw2015_fuel_gauge_v3.4.c
+++ b/drivers/power/mediatek/battery/cw2015_fuel_gauge_v3.4.c
@@ -33,7 +33,7 @@ extern struct hardware_info current_coulo_info;
 #define DC_CHARGING_FILE "/sys/class/power_supply/ac/online"
 */
 #define queue_delayed_work_time  8000
-#define CW_PROPERTIES "cw-bat"
+//#define CW_PROPERTIES "cw-bat"
 
 #define REG_VERSION             0x0
 #define REG_VCELL               0x2


### PR DESCRIPTION
The `sysfs` props from this fuel gauge driver are incomplete/incorrect at times and they just break battery status reporting on GNU/Linux distros running on top of this kernel.

Fixes https://github.com/HelloVolla/ubuntu-touch-beta-tests/issues/63.