### PR TITLE
yggdrasilx: search for receiving context pid in global namespace

### DIFF
--- a/drivers/android/binder.c
+++ b/drivers/android/binder.c
@@ -216,6 +216,9 @@ static int binder_set_stop_on_user_error(const char *val,
 module_param_call(stop_on_user_error, binder_set_stop_on_user_error,
 	param_get_int, &binder_stop_on_user_error, 0644);
 
+static bool binder_global_pid_lookups = true;
+module_param_named(global_pid_lookups, binder_global_pid_lookups, bool, S_IRUGO);
+
 #define binder_debug(mask, x...) \
 	do { \
 		if (binder_debug_mask & mask) \
@@ -5206,7 +5209,7 @@ retry:
 			trd->sender_pid =
 				task_tgid_nr_ns(sender,
 						task_active_pid_ns(current));
-			if (trd->sender_pid == 0)
+			if (binder_global_pid_lookups && trd->sender_pid == 0)
 				trd->sender_pid = task_tgid_nr(sender);
 		} else {
 			trd->sender_pid = 0;

--- a/drivers/android/binder.c
+++ b/drivers/android/binder.c
@@ -5206,6 +5206,8 @@ retry:
 			trd->sender_pid =
 				task_tgid_nr_ns(sender,
 						task_active_pid_ns(current));
+			if (trd->sender_pid == 0)
+				trd->sender_pid = task_tgid_nr(sender);
 		} else {
 			trd->sender_pid = 0;
 		}


### PR DESCRIPTION
yggdrasilx doesn't have the camera permission changes merged into Halium 10.0 yet,
but this change will be required as soon as that happens.